### PR TITLE
fix: include necessary header for Segment

### DIFF
--- a/headers/piecewise_cost_merge_integer_template_link_colcor.h
+++ b/headers/piecewise_cost_merge_integer_template_link_colcor.h
@@ -9,6 +9,7 @@
 #include "bit_write.h"
 #include "caltime.h"
 #include "lr.h"
+#include "piecewise_cost_merge_integer_template_link.h"
 #define INF 0x7f7fffff
 #include "stx-btree/btree.h"
 #include "stx-btree/btree_map.h"


### PR DESCRIPTION
# Bug
Can't build successfully because of missing header.

# Env
WSL2 Ubuntu 22.04 LTS

# How to reproduce
follow the README to prepare the env and try to build this program, and there will be an error:
```sh
In file included from /path/to/Learn-to-Compress/experiments/poly_int_template.cpp:7:
/path/to/Learn-to-Compress/headers/piecewise_cost_merge_integer_template_link_colcor.h: In member function ‘uint8_t* Codecset::Leco_cost_merge_test_link_colcor<T>::encodeArray8_int(T*, size_t, uint8_t*, size_t)’:
/path/to/Learn-to-Compress/headers/piecewise_cost_merge_integer_template_link_colcor.h:430:13: error: ‘Segment’ was not declared in this scope; did you mean ‘newsegment’?
  430 |             Segment<int64_t> head(0, 0, 0, 0, 0, 10000);
      |             ^~~~~~~
      |             newsegment
```

# Fix
Include the correct header, just like ```headers/piecewise_cost_merge_integer_template_double_link.h```.